### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ UIFont-DynamicFontSize
 This category is meant to help with using the Dynamic Text sizes introduced in iOS7. I have put in checks to make sure user is running iOS7 or I just return the normal UIFont. You can use your own font and scale the size of the font.
 
 
-Install Via Cocoapods:
+Install Via CocoaPods:
 ----------------------
 
     pod 'UIFont-DynamicFontControl', '~> 0.1'


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
